### PR TITLE
Fix task edit reload, minor cleanup

### DIFF
--- a/client/app/components/login-form/login-form-component.ts
+++ b/client/app/components/login-form/login-form-component.ts
@@ -5,7 +5,7 @@ export class LoginFormComponent {
   private static selector = 'ngc-login-form';
   private static templateUrl = '/dist/components/login-form/login-form-component.html';
   private static options = {
-    scope: {
+    bindToController: {
       errorMessage: '=',
       fireSubmit: '&onSubmit'
     }

--- a/client/app/components/task-edit/task-edit-component.ts
+++ b/client/app/components/task-edit/task-edit-component.ts
@@ -1,4 +1,5 @@
 import {Inject} from 'utils/di';
+import 'rx';
 
 export class TaskEditComponent {
 
@@ -7,6 +8,7 @@ export class TaskEditComponent {
   private static options = {};
 
   private task;
+  private errorMessage;
 
   constructor(
     @Inject('$log') private $log,
@@ -16,8 +18,15 @@ export class TaskEditComponent {
     @Inject('router') private router
   ) {
 
-    this.task = this.tasksStore.getTaskById(
-      this.$stateParams._id);
+    let taskId = this.$stateParams._id;
+     
+    this.task = this.tasksStore.getTaskById(taskId);
+      
+    this.tasksStore.getTasksObservable
+      .subscribe(
+        (tasks) => this.task = this.tasksStore.getTaskById(taskId),
+        (error) => this.errorMessage = error
+      );
   }
 
   updateTask(task) {

--- a/client/app/components/task/task-component.ts
+++ b/client/app/components/task/task-component.ts
@@ -9,7 +9,7 @@ export class TaskComponent {
   private static selector = 'ngc-task';
   private static templateUrl = '/dist/components/task/task-component.html';
   private static options = {
-    scope: {
+    bindToController: {
       task: '=',
       user: '='
     }
@@ -24,7 +24,6 @@ export class TaskComponent {
     @Inject('router') private router,
     @Inject('tasksActions') private tasksActions
     ) {
-    this.$log.log('task-component');
   }
   
   private deleteTask() {

--- a/client/app/services/router/router-service.ts
+++ b/client/app/services/router/router-service.ts
@@ -21,9 +21,6 @@ export class RouterConfig {
       .state('tasks', {
         url: '/tasks',
         views: {
-          'actionArea@tasks': {
-            template: ''
-          },
           '': {
             template: '<ngc-tasks></ngc-tasks>'
           }


### PR DESCRIPTION
- Fix a bug on task edit route reload (shows empty form)
- Use bindToController, instead of scope
- Remove empty route from router service

Hey @winkerVSbecks here is another one. This is about task edit component display a blank form on page reload. The fix make this component not-dumb. However this component is used in routing and from my experience in black crows and working on this course, it seems that routed component fit better when they are smart.

In either case I have examples of dumb component in the repo anyway. 
Also, there is some minor cleanup tagged along, bindToController is one of them. 